### PR TITLE
Fix persona create/list missing project_id (422)

### DIFF
--- a/modules/neuralops-react-app/src/components/chat/MessageInput.tsx
+++ b/modules/neuralops-react-app/src/components/chat/MessageInput.tsx
@@ -98,10 +98,10 @@ export function MessageInput({
   const lastTypingSentRef = useRef(0);
 
   useEffect(() => {
-    listPersonas()
+    listPersonas(projectId)
       .then((ps) => setPersonas(ps.map((p) => ({ id: p.id, name: p.name }))))
       .catch(() => {});
-  }, []);
+  }, [projectId]);
 
   useEffect(() => {
     const ta = textareaRef.current;
@@ -281,8 +281,8 @@ export function MessageInput({
       <ListMCPsDialog  open={activeForm === "list-mcps"}     onClose={() => setActiveForm(null)} />
       <AddAgentForm    open={activeForm === "add-agent"}     onClose={() => setActiveForm(null)} />
       <ListAgentsDialog open={activeForm === "list-agents"}  onClose={() => setActiveForm(null)} />
-      <AddPersonaForm  open={activeForm === "add-persona"}   onClose={() => setActiveForm(null)} />
-      <ListPersonasDialog open={activeForm === "list-personas"} onClose={() => setActiveForm(null)} />
+      <AddPersonaForm  open={activeForm === "add-persona"}   onClose={() => setActiveForm(null)} projectId={projectId} />
+      <ListPersonasDialog open={activeForm === "list-personas"} onClose={() => setActiveForm(null)} projectId={projectId} />
 
       <div className="relative border-t border-sidebar-border bg-sidebar px-3 py-3">
         {file && (

--- a/modules/neuralops-react-app/src/components/chat/slash-commands/forms/AddPersonaForm.tsx
+++ b/modules/neuralops-react-app/src/components/chat/slash-commands/forms/AddPersonaForm.tsx
@@ -37,9 +37,11 @@ const EMPTY: FormState = {
 export function AddPersonaForm({
   open,
   onClose,
+  projectId,
 }: {
   open: boolean;
   onClose: () => void;
+  projectId?: string | null;
 }) {
   const [models, setModels] = useState<AIModel[]>([]);
   const [agents, setAgents] = useState<Agent[]>([]);
@@ -65,6 +67,10 @@ export function AddPersonaForm({
     e.preventDefault();
     const hasTarget =
       form.source_type === "agent" ? !!form.agent_id : !!form.model_id;
+    if (!projectId) {
+      toast.error("Open a project first -- personas belong to a project.");
+      return;
+    }
     if (!form.name || !hasTarget) {
       toast.error(
         !form.name ? "Name is required" : `Select a ${form.source_type}`,
@@ -73,7 +79,7 @@ export function AddPersonaForm({
     }
     setSaving(true);
     try {
-      await createPersona({
+      await createPersona(projectId, {
         name: form.name,
         description: form.description || undefined,
         source_type: form.source_type,

--- a/modules/neuralops-react-app/src/components/chat/slash-commands/forms/ListCards.tsx
+++ b/modules/neuralops-react-app/src/components/chat/slash-commands/forms/ListCards.tsx
@@ -164,15 +164,15 @@ export function ListAgentsDialog({ open, onClose }: { open: boolean; onClose: ()
 
 // ── Personas ──────────────────────────────────────────────────────────────────
 
-export function ListPersonasDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+export function ListPersonasDialog({ open, onClose, projectId }: { open: boolean; onClose: () => void; projectId?: string | null }) {
   const [items, setItems] = useState<Persona[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!open) return;
     setLoading(true);
-    listPersonas().then(setItems).catch(() => {}).finally(() => setLoading(false));
-  }, [open]);
+    listPersonas(projectId).then(setItems).catch(() => {}).finally(() => setLoading(false));
+  }, [open, projectId]);
 
   async function remove(id: string, name: string) {
     await deletePersona(id);

--- a/modules/neuralops-react-app/src/routes/app.agents.tsx
+++ b/modules/neuralops-react-app/src/routes/app.agents.tsx
@@ -26,7 +26,8 @@ import { listAIModels, createAIModel, deleteAIModel } from "@/services/ai-models
 import { listMCPServers, createMCPServer, deleteMCPServer } from "@/services/mcp-servers.service";
 import { listAgents, createAgent, deleteAgent } from "@/services/agents.service";
 import { listPersonas, createPersona, patchPersona, deletePersona } from "@/services/personas.service";
-import type { AIModel, MCPServer, Agent, Persona } from "@/types";
+import { listProjects } from "@/services/projects.service";
+import type { AIModel, MCPServer, Agent, Persona, Project } from "@/types";
 
 export const Route = createFileRoute("/app/agents")({
   validateSearch: (s: Record<string, unknown>) => ({ tab: (s.tab as string) || "mcps" }),
@@ -502,6 +503,11 @@ function PersonasTab() {
   const [personas, setPersonas] = useState<Persona[]>([]);
   const [models, setModels] = useState<AIModel[]>([]);
   const [agents, setAgents] = useState<Agent[]>([]);
+  // Personas are project-owned (DECISIONS.md #1, #92) -- unlike
+  // models/mcps/agents, they're not company-wide, so this tab needs its own
+  // project selector to know which project's personas to list/create.
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [projectId, setProjectId] = useState<string>("");
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState({
@@ -549,18 +555,29 @@ function PersonasTab() {
   }
 
   useEffect(() => {
-    Promise.all([listPersonas(), listAIModels(), listAgents()])
-      .then(([p, m, a]) => { setPersonas(p); setModels(m); setAgents(a); })
+    Promise.all([listProjects(), listAIModels(), listAgents()])
+      .then(([pr, m, a]) => {
+        setProjects(pr);
+        setModels(m);
+        setAgents(a);
+        if (pr.length > 0) setProjectId((prev) => prev || pr[0].id);
+      })
       .catch(() => {});
   }, []);
 
+  useEffect(() => {
+    if (!projectId) { setPersonas([]); return; }
+    listPersonas(projectId).then(setPersonas).catch(() => {});
+  }, [projectId]);
+
   async function handleCreate() {
+    if (!projectId) { toast.error("Select a project first."); return; }
     if (!form.name) { toast.error("Name is required."); return; }
     if (form.source_type === "model" && !form.model_id) { toast.error("Select a model."); return; }
     if (form.source_type === "agent" && !form.agent_id) { toast.error("Select an agent."); return; }
     setSaving(true);
     try {
-      const p = await createPersona({
+      const p = await createPersona(projectId, {
         name: form.name,
         description: form.description || undefined,
         source_type: form.source_type,
@@ -594,13 +611,25 @@ function PersonasTab() {
 
   return (
     <div className="space-y-3">
-      <div className="flex justify-end">
-        <Button size="sm" onClick={() => setOpen(true)}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="w-56">
+          <Select value={projectId} onValueChange={setProjectId}>
+            <SelectTrigger><SelectValue placeholder="Select a project..." /></SelectTrigger>
+            <SelectContent>
+              {projects.map((pr) => (
+                <SelectItem key={pr.id} value={pr.id}>{pr.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button size="sm" onClick={() => setOpen(true)} disabled={!projectId}>
           <Plus className="h-4 w-4 mr-1" /> Add Persona
         </Button>
       </div>
 
-      {personas.length === 0 ? (
+      {!projectId ? (
+        <EmptyState icon={User} label="projects -- create one first" />
+      ) : personas.length === 0 ? (
         <EmptyState icon={User} label="personas" />
       ) : (
         <div className="space-y-2">

--- a/modules/neuralops-react-app/src/services/personas.service.ts
+++ b/modules/neuralops-react-app/src/services/personas.service.ts
@@ -1,14 +1,18 @@
 import { apiJson } from "./api-client";
 import type { Persona } from "@/types";
 
-export async function listPersonas(): Promise<Persona[]> {
-  return apiJson<Persona[]>("/api/v1/personas/");
+// Personas are project-owned (see DECISIONS.md #1, #92) -- both endpoints
+// require project_id. listPersonas() returns [] early instead of calling
+// the API with an empty project_id, which the backend would 422 on.
+export async function listPersonas(projectId?: string | null): Promise<Persona[]> {
+  if (!projectId) return [];
+  return apiJson<Persona[]>(`/api/v1/personas/?project_id=${encodeURIComponent(projectId)}`);
 }
 
-export async function createPersona(input: Partial<Persona>): Promise<Persona> {
+export async function createPersona(projectId: string, input: Partial<Persona>): Promise<Persona> {
   return apiJson<Persona>("/api/v1/personas/", {
     method: "POST",
-    body: JSON.stringify(input),
+    body: JSON.stringify({ ...input, project_id: projectId }),
   });
 }
 


### PR DESCRIPTION
Personas became project-owned in #92 but every frontend call site (AddPersonaForm, ListPersonasDialog, MessageInput's @mention list, AI Intelligence Personas tab) kept calling listPersonas()/createPersona() with no project_id -- backend 422s on the missing required field. Threaded projectId through all 4 call sites; added a project selector to the Personas tab, which previously had no project context at all.