### PR TITLE
Fix MCP server + Agent create missing project_id (422)

### DIFF
--- a/modules/neuralops-react-app/src/components/chat/MessageInput.tsx
+++ b/modules/neuralops-react-app/src/components/chat/MessageInput.tsx
@@ -277,9 +277,9 @@ export function MessageInput({
     <>
       <AddModelForm    open={activeForm === "add-model"}     onClose={() => setActiveForm(null)} />
       <ListModelsDialog open={activeForm === "list-models"}  onClose={() => setActiveForm(null)} />
-      <AddMCPForm      open={activeForm === "add-mcp"}       onClose={() => setActiveForm(null)} />
+      <AddMCPForm      open={activeForm === "add-mcp"}       onClose={() => setActiveForm(null)} projectId={projectId} />
       <ListMCPsDialog  open={activeForm === "list-mcps"}     onClose={() => setActiveForm(null)} />
-      <AddAgentForm    open={activeForm === "add-agent"}     onClose={() => setActiveForm(null)} />
+      <AddAgentForm    open={activeForm === "add-agent"}     onClose={() => setActiveForm(null)} projectId={projectId} />
       <ListAgentsDialog open={activeForm === "list-agents"}  onClose={() => setActiveForm(null)} />
       <AddPersonaForm  open={activeForm === "add-persona"}   onClose={() => setActiveForm(null)} projectId={projectId} />
       <ListPersonasDialog open={activeForm === "list-personas"} onClose={() => setActiveForm(null)} projectId={projectId} />

--- a/modules/neuralops-react-app/src/components/chat/slash-commands/forms/AddAgentForm.tsx
+++ b/modules/neuralops-react-app/src/components/chat/slash-commands/forms/AddAgentForm.tsx
@@ -39,9 +39,11 @@ const EMPTY: FormState = {
 export function AddAgentForm({
   open,
   onClose,
+  projectId,
 }: {
   open: boolean;
   onClose: () => void;
+  projectId?: string | null;
 }) {
   const [models, setModels] = useState<AIModel[]>([]);
   const [mcps, setMcps] = useState<MCPServer[]>([]);
@@ -66,9 +68,13 @@ export function AddAgentForm({
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     if (!form.name || !form.model_id) return;
+    if (!projectId) {
+      toast.error("Open a project first -- agents belong to a project.");
+      return;
+    }
     setSaving(true);
     try {
-      await createAgent({
+      await createAgent(projectId, {
         name: form.name,
         description: form.description || undefined,
         model_id: form.model_id,

--- a/modules/neuralops-react-app/src/components/chat/slash-commands/forms/AddMCPForm.tsx
+++ b/modules/neuralops-react-app/src/components/chat/slash-commands/forms/AddMCPForm.tsx
@@ -32,9 +32,11 @@ const EMPTY: FormState = {
 export function AddMCPForm({
   open,
   onClose,
+  projectId,
 }: {
   open: boolean;
   onClose: () => void;
+  projectId?: string | null;
 }) {
   const [form, setForm] = useState<FormState>(EMPTY);
   const [saving, setSaving] = useState(false);
@@ -51,9 +53,13 @@ export function AddMCPForm({
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     if (!form.name || !form.url) return;
+    if (!projectId) {
+      toast.error("Open a project first -- MCP servers belong to a project.");
+      return;
+    }
     setSaving(true);
     try {
-      await createMCPServer({ ...form });
+      await createMCPServer(projectId, { ...form });
       toast.success(`MCP server "${form.name}" registered`);
       setForm(EMPTY);
       onClose();

--- a/modules/neuralops-react-app/src/routes/app.agents.tsx
+++ b/modules/neuralops-react-app/src/routes/app.agents.tsx
@@ -219,6 +219,11 @@ function ModelsTab() {
 
 function MCPServersTab() {
   const [servers, setServers] = useState<MCPServer[]>([]);
+  // MCP servers are project-owned at creation (same pattern as Personas/
+  // Agents) -- listing is company-wide, but creating requires project_id
+  // or the backend 422s.
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [projectId, setProjectId] = useState<string>("");
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState({
@@ -232,16 +237,21 @@ function MCPServersTab() {
 
   useEffect(() => {
     listMCPServers().then(setServers).catch(() => {});
+    listProjects().then((pr) => {
+      setProjects(pr);
+      if (pr.length > 0) setProjectId((prev) => prev || pr[0].id);
+    }).catch(() => {});
   }, []);
 
   async function handleCreate() {
+    if (!projectId) { toast.error("Select a project first."); return; }
     if (!form.name || !form.url) {
       toast.error("Name and URL are required.");
       return;
     }
     setSaving(true);
     try {
-      const s = await createMCPServer({
+      const s = await createMCPServer(projectId, {
         name: form.name,
         description: form.description || undefined,
         server_type: "remote",
@@ -276,8 +286,18 @@ function MCPServersTab() {
 
   return (
     <div className="space-y-3">
-      <div className="flex justify-end">
-        <Button size="sm" onClick={() => setOpen(true)}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="w-56">
+          <Select value={projectId} onValueChange={setProjectId}>
+            <SelectTrigger><SelectValue placeholder="Select a project..." /></SelectTrigger>
+            <SelectContent>
+              {projects.map((pr) => (
+                <SelectItem key={pr.id} value={pr.id}>{pr.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button size="sm" onClick={() => setOpen(true)} disabled={!projectId}>
           <Plus className="h-4 w-4 mr-1" /> Add MCP Server
         </Button>
       </div>
@@ -359,6 +379,11 @@ function AgentsTab() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [models, setModels] = useState<AIModel[]>([]);
   const [mcps, setMcps] = useState<MCPServer[]>([]);
+  // Agents are project-owned at creation (same pattern as Personas/MCP
+  // servers) -- listing is company-wide, but creating requires project_id
+  // or the backend 422s.
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [projectId, setProjectId] = useState<string>("");
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState({
@@ -370,19 +395,23 @@ function AgentsTab() {
   });
 
   useEffect(() => {
-    Promise.all([listAgents(), listAIModels(), listMCPServers()])
-      .then(([a, m, s]) => { setAgents(a); setModels(m); setMcps(s); })
+    Promise.all([listAgents(), listAIModels(), listMCPServers(), listProjects()])
+      .then(([a, m, s, pr]) => {
+        setAgents(a); setModels(m); setMcps(s); setProjects(pr);
+        if (pr.length > 0) setProjectId((prev) => prev || pr[0].id);
+      })
       .catch(() => {});
   }, []);
 
   async function handleCreate() {
+    if (!projectId) { toast.error("Select a project first."); return; }
     if (!form.name || !form.model_id) {
       toast.error("Name and Model are required.");
       return;
     }
     setSaving(true);
     try {
-      const a = await createAgent({
+      const a = await createAgent(projectId, {
         name: form.name,
         description: form.description || undefined,
         model_id: form.model_id,
@@ -413,8 +442,18 @@ function AgentsTab() {
 
   return (
     <div className="space-y-3">
-      <div className="flex justify-end">
-        <Button size="sm" onClick={() => setOpen(true)}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="w-56">
+          <Select value={projectId} onValueChange={setProjectId}>
+            <SelectTrigger><SelectValue placeholder="Select a project..." /></SelectTrigger>
+            <SelectContent>
+              {projects.map((pr) => (
+                <SelectItem key={pr.id} value={pr.id}>{pr.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button size="sm" onClick={() => setOpen(true)} disabled={!projectId}>
           <Plus className="h-4 w-4 mr-1" /> Add Agent
         </Button>
       </div>

--- a/modules/neuralops-react-app/src/services/agents.service.ts
+++ b/modules/neuralops-react-app/src/services/agents.service.ts
@@ -1,6 +1,9 @@
 import { apiJson } from "./api-client";
 import type { Agent } from "@/types";
 
+// GET is company-wide (row-visibility), no project_id needed. POST is
+// project-owned at creation -- same pattern as Persona/MCPServer -- and
+// requires project_id or the backend 422s ("Field required").
 export async function listAgents(): Promise<Agent[]> {
   return apiJson<Agent[]>("/api/v1/agents/");
 }
@@ -9,10 +12,10 @@ export async function getAgent(id: string): Promise<Agent> {
   return apiJson<Agent>(`/api/v1/agents/${id}/`);
 }
 
-export async function createAgent(input: Partial<Agent>): Promise<Agent> {
+export async function createAgent(projectId: string, input: Partial<Agent>): Promise<Agent> {
   return apiJson<Agent>("/api/v1/agents/", {
     method: "POST",
-    body: JSON.stringify(input),
+    body: JSON.stringify({ ...input, project_id: projectId }),
   });
 }
 

--- a/modules/neuralops-react-app/src/services/mcp-servers.service.ts
+++ b/modules/neuralops-react-app/src/services/mcp-servers.service.ts
@@ -1,16 +1,20 @@
 import { apiJson } from "./api-client";
 import type { MCPServer } from "@/types";
 
+// GET is company-wide (row-visibility), no project_id needed. POST is
+// project-owned at creation -- same pattern as Persona/Agent -- and
+// requires project_id or the backend 422s ("Field required").
 export async function listMCPServers(): Promise<MCPServer[]> {
   return apiJson<MCPServer[]>("/api/v1/mcp-servers/");
 }
 
 export async function createMCPServer(
+  projectId: string,
   input: Partial<MCPServer>,
 ): Promise<MCPServer> {
   return apiJson<MCPServer>("/api/v1/mcp-servers/", {
     method: "POST",
-    body: JSON.stringify(input),
+    body: JSON.stringify({ ...input, project_id: projectId }),
   });
 }
 


### PR DESCRIPTION
Same bug class as the persona fix -- MCPServer and AIAgent are also project-owned at creation (POST /mcp-servers/ and POST /agents/ both require project_id), but none of the 6 frontend call sites (AddMCPForm, AddAgentForm, MessageInput's slash commands, and the AI Intelligence MCP Servers/Agents tabs) ever sent it. Threaded projectId through mcp-servers.service.ts and agents.service.ts, added guards to both forms, and added a project selector to both AI Intelligence tabs (same as the earlier Personas tab fix).